### PR TITLE
Allow log and error functions to be specified as options.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,14 +19,14 @@ module.exports = function(options) {
     throw new gutil.PluginError('svgicons2svgfont', 'Missing options.fontName');
   }
 
-  options.log = function() {
+  options.log = options.log || function() {
     gutil.log.apply(gutil, ['gulp-svgicons2svgfont: '].concat(
       [].slice.call(arguments, 0).concat()));
   };
 
   var stream = new Stream.Transform({objectMode: true});
 
-  options.error = function() {
+  options.error = options.error || function() {
     stream.emit('error', new PluginError('svgicons2svgfont',
       [].slice.call(arguments, 0).concat()));
   };


### PR DESCRIPTION
So, if you make this change, then you can use gulp-iconfont like this:

``` javascript
gulp.task('iconfont', function() {
    gulp.src(['src/iconfont/*.svg'])
        .pipe(iconfont({
            fontName: 'iconfont',
            log: function(){}
        }))
  ...
```

without needing to make any changes to gulp-iconfont itself.
