### PR TITLE
Support 5digit codepoint for supplementary-plane characters

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,7 +58,7 @@ module.exports = function(options) {
     // Map each icons to their corresponding glyphs
     var glyphs = files.map(function(file) {
       // Creating an object for each icon
-      var matches = path.basename(file.path).match(/^(?:u([0-9a-f]{4,5})\-)?(.*).svg$/i)
+      var matches = path.basename(file.path).match(/^(?:u([0-9a-f]{4,6})\-)?(.*).svg$/i)
         , glyph = {
           name: matches[2],
           codepoint: 0,


### PR DESCRIPTION
A little fix related to this issue.
https://github.com/nfroidure/gulp-iconfont/issues/25
