### PR TITLE
fix a bug where metadataProvider slices items off the file list while its being mutated

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ var fileSorter = require('svgicons2svgfont/src/filesorter');
 
 module.exports = function(options) {
   var filesBuffer = [];
+  var filenamesAdded = [];
   var metadataProvider;
   var inputStream = new Stream.Transform({ objectMode: true });
   var outputStream = new Stream.PassThrough({ objectMode: true });
@@ -114,6 +115,9 @@ module.exports = function(options) {
       return fileSorter(fileA.path, fileB.path);
     });
 
+    // make an index of filenames yet to have metadata provided
+    filenamesAdded = filesBuffer.map(function(file) { return file.path; });
+
     // Wrap icons for the underlying lib
     filesBuffer.forEach(function(file) {
       var iconStream;
@@ -134,8 +138,8 @@ module.exports = function(options) {
         iconStream.metadata = theMetadata;
 
         fontStream.write(iconStream);
-        filesBuffer.splice(filesBuffer.indexOf(file), 1);
-        if(0 === filesBuffer.length) {
+        filenamesAdded.splice(filenamesAdded.indexOf(file), 1);
+        if(0 === filenamesAdded.length) {
           fontStream.end();
         }
       });


### PR DESCRIPTION
I ran into an issue where gulp-svgicons2svgfont was only applying the metadataProvider to every other svg file, and the final file wasn't being generated. My theory is that I was using `require("babel/register")` in Gulp, and it shims forEach into something closer to a for loop.

Since this bug possibly relies on Babel, and I didn't want to add it to the project just for the test, I just used a different method for defining "progress" (i.e., I made a new variable to index files). Since all the tests pass, it seems okay to try for a PR, but let me know if you want me to explore writing a real test for this case.